### PR TITLE
Bugfix/kyv 745 fix accounting export data repository fetch method parameters with date type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 infra/settings.xml
 infra/kafka/clusters.json
+mockedSap/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -397,11 +397,12 @@ services:
   sftp:
     image: atmoz/sftp
     volumes:
-      - "./mockedSap/upload:/home/username/upload"
+      - "./mockedSap/share:/home/sftp/share"
+      - "./infra/mockedSap/init.sh:/etc/sftp.d/init.sh:ro"
     ports:
       - "2222:22"
     networks: [common]
-    command: username:password:1000
+    command: sftp:password:::share
 
 volumes:
   esdata1:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -394,6 +394,15 @@ services:
       ACTIVEMQ_MIN_MEMORY: 512
       ACTIVEMQ_MAX_MEMORY: 2048
 
+  sftp:
+    image: atmoz/sftp
+    volumes:
+      - "./mockedSap/upload:/home/username/upload"
+    ports:
+      - "2222:22"
+    networks: [common]
+    command: username:password:1000
+
 volumes:
   esdata1:
     driver: local

--- a/infra/mockedSap/init.sh
+++ b/infra/mockedSap/init.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+for user_home in /home/* ; do
+  if [ -d "$user_home" ]; then
+    username=`basename $user_home`
+    echo "Setup $user_home/share folder for $username"
+    mkdir -p $user_home/share
+    chown -R $username:users $user_home/share
+  fi
+done

--- a/orderapi/src/main/java/fi/hel/verkkokauppa/order/api/AccountingExportController.java
+++ b/orderapi/src/main/java/fi/hel/verkkokauppa/order/api/AccountingExportController.java
@@ -14,6 +14,7 @@ import fi.hel.verkkokauppa.order.service.accounting.AccountingSlipService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -63,7 +64,6 @@ public class AccountingExportController {
     @GetMapping(value = "/accounting/export", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<AccountingExportDataDto>> ExportAccountingData() {
         List<AccountingExportDataDto> result = new ArrayList<>();
-        accountingExportService.export("test","share/testi.txt");
         try {
             List<AccountingExportData> accountingExportDataList = accountingSearchService.getNotExportedAccountingExportData();
 
@@ -100,7 +100,8 @@ public class AccountingExportController {
     }
 
     @GetMapping(value = "/accounting/export/getByTimestamp", produces = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<List<AccountingExportDataDto>> getAccountExportDataWithTimestamp(@RequestParam(value = "timestamp") String timestamp) {
+    public ResponseEntity<List<AccountingExportDataDto>> getAccountExportDataWithTimestamp(@RequestParam(value = "timestamp")
+                                                                                           @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate timestamp) {
         try {
             List<AccountingExportData> exportDatas = accountingExportDataService.getAccountingExportDataByTimestamp(timestamp);
             List<AccountingExportDataDto> result = new ArrayList<>();

--- a/orderapi/src/main/java/fi/hel/verkkokauppa/order/api/AccountingExportController.java
+++ b/orderapi/src/main/java/fi/hel/verkkokauppa/order/api/AccountingExportController.java
@@ -63,7 +63,7 @@ public class AccountingExportController {
     @GetMapping(value = "/accounting/export", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<AccountingExportDataDto>> ExportAccountingData() {
         List<AccountingExportDataDto> result = new ArrayList<>();
-
+        accountingExportService.export("test","share/testi.txt");
         try {
             List<AccountingExportData> accountingExportDataList = accountingSearchService.getNotExportedAccountingExportData();
 

--- a/orderapi/src/main/java/fi/hel/verkkokauppa/order/repository/jpa/AccountingExportDataRepository.java
+++ b/orderapi/src/main/java/fi/hel/verkkokauppa/order/repository/jpa/AccountingExportDataRepository.java
@@ -1,18 +1,17 @@
 package fi.hel.verkkokauppa.order.repository.jpa;
 
 import fi.hel.verkkokauppa.order.model.accounting.AccountingExportData;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Repository
 public interface AccountingExportDataRepository extends ElasticsearchRepository<AccountingExportData, String> {
 
-    List<AccountingExportData> findAllByTimestamp(String timestamp);
+    List<AccountingExportData> findAllByTimestamp(LocalDate timestamp);
 
-    int countAllByExportedStartsWith(String year);
+    int countAllByExportedGreaterThanEqualAndExportedLessThanEqual(LocalDate start, LocalDate end);
 
 }

--- a/orderapi/src/main/java/fi/hel/verkkokauppa/order/service/accounting/AccountingExportDataService.java
+++ b/orderapi/src/main/java/fi/hel/verkkokauppa/order/service/accounting/AccountingExportDataService.java
@@ -136,7 +136,7 @@ public class AccountingExportDataService {
         );
     }
 
-    public List<AccountingExportData> getAccountingExportDataByTimestamp(String timestamp) {
+    public List<AccountingExportData> getAccountingExportDataByTimestamp(LocalDate timestamp) {
         List<AccountingExportData> exportData = exportDataRepository.findAllByTimestamp(timestamp);
 
         if (exportData != null && !exportData.isEmpty()) {
@@ -146,7 +146,7 @@ public class AccountingExportDataService {
         throw new CommonApiException(
                 HttpStatus.NOT_FOUND,
                 new Error("accounting-export-data-not-found-from-backend",
-                        "accounting export data with timestamp [" + timestamp + "]  not found from backend")
+                        "accounting export data with timestamp [" + timestamp.toString() + "]  not found from backend")
         );
     }
 

--- a/orderapi/src/main/java/fi/hel/verkkokauppa/order/service/accounting/AccountingExportService.java
+++ b/orderapi/src/main/java/fi/hel/verkkokauppa/order/service/accounting/AccountingExportService.java
@@ -14,6 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
@@ -29,6 +30,9 @@ public class AccountingExportService {
     public static final int RUNNING_NUMBER_LENGTH = 4;
 
     private Logger log = LoggerFactory.getLogger(AccountingExportService.class);
+
+    @Value("${spring.profiles.active:}")
+    private String activeProfile;
 
     @Value("${sap.sftp.server.url}")
     private String sftpServerUrl;
@@ -123,6 +127,12 @@ public class AccountingExportService {
         jschSession.setPassword(sftpServerPassword);
 
         jsch.setKnownHosts(sshKnownHostsPath);
+
+        if (activeProfile != null && activeProfile.equals("local")) {
+            java.util.Properties config = new java.util.Properties();
+            config.put("StrictHostKeyChecking", "no");
+            jschSession.setConfig(config);
+        }
 
         jschSession.connect();
         log.info("Connected to the server succesfully");

--- a/orderapi/src/main/resources/application-local.properties
+++ b/orderapi/src/main/resources/application-local.properties
@@ -5,8 +5,8 @@ elasticsearch.service.local.environment=true
 
 payment.card_token.encryption.password=testest
 
-sap.sftp.server.url=http://host.docker.internal:2222
-sap.sftp.server.username=username
+sap.sftp.server.url=localhost
+sap.sftp.server.username=sftp
 sap.sftp.server.password=password
 
 kafka.client.authentication.enabled=false

--- a/orderapi/src/main/resources/application-local.properties
+++ b/orderapi/src/main/resources/application-local.properties
@@ -5,9 +5,9 @@ elasticsearch.service.local.environment=true
 
 payment.card_token.encryption.password=testest
 
-sap.sftp.server.url=
-sap.sftp.server.username=
-sap.sftp.server.password=
+sap.sftp.server.url=sftp
+sap.sftp.server.username=username
+sap.sftp.server.password=password
 
 kafka.client.authentication.enabled=false
 serviceconfiguration.url=http://host.docker.internal:8187/serviceconfiguration/

--- a/orderapi/src/main/resources/application-local.properties
+++ b/orderapi/src/main/resources/application-local.properties
@@ -5,7 +5,7 @@ elasticsearch.service.local.environment=true
 
 payment.card_token.encryption.password=testest
 
-sap.sftp.server.url=sftp
+sap.sftp.server.url=http://host.docker.internal:2222
 sap.sftp.server.username=username
 sap.sftp.server.password=password
 


### PR DESCRIPTION
Changed the repository method count all account export datas by exported year to work with LocalDate type - requires counting by date range from first to last day of the provided year. Local environment uses now a mock sftp server to mock the functionality of SAP in production.