### PR TITLE
[KYV-1125] Fix error email sending

### DIFF
--- a/eventsapi/src/main/java/fi/hel/verkkokauppa/events/notification/ErrorEmailNotificationListener.java
+++ b/eventsapi/src/main/java/fi/hel/verkkokauppa/events/notification/ErrorEmailNotificationListener.java
@@ -70,7 +70,7 @@ public class ErrorEmailNotificationListener extends BaseEmailNotifier<ErrorMessa
         sendNotificationToEmail(
                 UUID.randomUUID().toString(),
                 receivers,
-                queueMessage.getEventType() + queueMessage.getMessage().substring(0, 500),
+                queueMessage.getEventType(),
                 queueMessage.getMessage(),
                 queueMessage.getCause(),
                 queueMessage


### PR DESCRIPTION
KYV-1125

Fixes error found in error email sending 

`localizedMessage":"Listener method 'void fi.hel.verkkokauppa.events.notification.ErrorEmailNotificationListener.consumeMessage(javax.jms.TextMessage)' threw exception; nested exception is java.lang.StringIndexOutOfBoundsException: begin 0, end 500, length 20"}`