### PR TITLE
Feature/kyv 1202 renewal multiple event fixes

### DIFF
--- a/common/src/main/java/fi/hel/verkkokauppa/common/events/EventType.java
+++ b/common/src/main/java/fi/hel/verkkokauppa/common/events/EventType.java
@@ -2,6 +2,7 @@ package fi.hel.verkkokauppa.common.events;
 
 public class    EventType {
     public static String MIT_CHARGE_PAID = "MIT_CHARGE_PAID";
+
     public static String PAYMENT_PAID = "PAYMENT_PAID";
     public static String PAYMENT_FAILED = "PAYMENT_FAILED";
     public static String SUBSCRIPTION_CREATED = "SUBSCRIPTION_CREATED";

--- a/common/src/main/java/fi/hel/verkkokauppa/common/events/EventType.java
+++ b/common/src/main/java/fi/hel/verkkokauppa/common/events/EventType.java
@@ -1,6 +1,7 @@
 package fi.hel.verkkokauppa.common.events;
 
-public class EventType {
+public class    EventType {
+    public static String MIT_CHARGE_PAID = "MIT_CHARGE_PAID";
     public static String PAYMENT_PAID = "PAYMENT_PAID";
     public static String PAYMENT_FAILED = "PAYMENT_FAILED";
     public static String SUBSCRIPTION_CREATED = "SUBSCRIPTION_CREATED";

--- a/orderapi/src/test/java/fi/hel/verkkokauppa/order/service/order/OrderServiceTest.java
+++ b/orderapi/src/test/java/fi/hel/verkkokauppa/order/service/order/OrderServiceTest.java
@@ -745,8 +745,12 @@ class OrderServiceTest extends TestUtils {
     void createSubsriptionOrderWithMerchantId() throws JsonProcessingException {
         // Helper test function to create new order with merchantId in orderItems, if initialization is done to merchants/namespace.
         String firstMerchantIdFromNamespace = getFirstMerchantIdFromNamespace("venepaikat");
-        JSONObject response = createMockAccountingForProductId("productId");
-        ResponseEntity<OrderAggregateDto> orderResponse = generateSubscriptionOrderData(1, 1L, Period.DAILY, 2);
+
+        // setup product for test
+        String productId = createMockProductMapping("venepaikat",firstMerchantIdFromNamespace);
+        JSONObject response = createMockAccountingForProductId(productId);
+
+        ResponseEntity<OrderAggregateDto> orderResponse = generateSubscriptionOrderData(1, 1L, Period.DAILY, 2, true, productId);
         OrderDto order = Objects.requireNonNull(orderResponse.getBody()).getOrder();
         log.info("Created order with merchantId: {}", firstMerchantIdFromNamespace);
         log.info("Kassa URL: {}", "https://localhost:3000/" + order.getOrderId() + "?user=" + order.getUser());

--- a/orderapi/src/test/java/fi/hel/verkkokauppa/order/test/utils/TestUtils.java
+++ b/orderapi/src/test/java/fi/hel/verkkokauppa/order/test/utils/TestUtils.java
@@ -6,6 +6,7 @@ import fi.hel.verkkokauppa.common.configuration.ServiceUrls;
 import fi.hel.verkkokauppa.common.constants.OrderType;
 import fi.hel.verkkokauppa.common.elastic.ElasticSearchRestClientResolver;
 import fi.hel.verkkokauppa.common.events.message.PaymentMessage;
+import fi.hel.verkkokauppa.common.productmapping.dto.ProductMappingDto;
 import fi.hel.verkkokauppa.common.rest.RestServiceClient;
 import fi.hel.verkkokauppa.common.rest.refund.RefundAggregateDto;
 import fi.hel.verkkokauppa.common.util.DateTimeUtil;
@@ -148,9 +149,13 @@ public class TestUtils extends DummyData {
     }
 
     public ResponseEntity<OrderAggregateDto> generateSubscriptionOrderData(int itemCount, long periodFrequency, String periodUnit, int periodCount) {
-        return generateSubscriptionOrderData(itemCount, periodFrequency, periodUnit, periodCount, true);
+        return generateSubscriptionOrderData(itemCount, periodFrequency, periodUnit, periodCount, true, "productId");
     }
     public ResponseEntity<OrderAggregateDto> generateSubscriptionOrderData(int itemCount, long periodFrequency, String periodUnit, int periodCount, boolean includeMetas) {
+        return generateSubscriptionOrderData(itemCount, periodFrequency, periodUnit, periodCount, includeMetas, "productId");
+    }
+
+    public ResponseEntity<OrderAggregateDto> generateSubscriptionOrderData(int itemCount, long periodFrequency, String periodUnit, int periodCount, boolean includeMetas, String productId) {
         Order order = generateDummyOrder();
 
         order.setEndDate(LocalDateTime.now().plusMonths(1));
@@ -167,7 +172,7 @@ public class TestUtils extends DummyData {
         orderItems.get(0).setPriceNet("98.5");
         orderItems.get(0).setPriceVat("1.5");
         orderItems.get(0).setVatPercentage("1.5");
-        orderItems.get(0).setProductId("productId");
+        orderItems.get(0).setProductId(productId);
         orderItems.get(0).setMerchantId(getFirstMerchantIdFromNamespace("venepaikat"));
         List<OrderItemMeta> orderItemMetas;
         if( includeMetas == true ) {
@@ -374,6 +379,19 @@ public class TestUtils extends DummyData {
         JSONArray result = new JSONArray(jsonResponse);
         log.info(result.toString());
         return result.getJSONObject(0).getString("merchantId");
+    }
+
+    public String createMockProductMapping(String namespace, String merchantId) {
+
+        String jsonResponse = restServiceClient.getClient().get()
+                .uri(serviceUrls.getProductMappingServiceUrl() + "/create?namespace=" + namespace +"&namespaceEntityId=automatedtestproduct&merchantId=" + merchantId)
+                .retrieve()
+                .bodyToMono(String.class)
+                .block();
+        log.info(jsonResponse);
+        JSONObject result = new JSONObject(jsonResponse);
+        log.info(result.toString());
+        return result.getString("productId");
     }
 
     public JSONObject createMockAccountingForProductId(String productId) throws JsonProcessingException {

--- a/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/model/PaymentStatus.java
+++ b/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/model/PaymentStatus.java
@@ -2,6 +2,7 @@ package fi.hel.verkkokauppa.payment.model;
 
 public interface PaymentStatus {
 	public static String CREATED = "payment_created";
+	public static String CREATED_FOR_MIT_CHARGE = "payment_created_for_mit_charge";
 	public static String PAID_ONLINE = "payment_paid_online";
 	public static String CANCELLED = "payment_cancelled";
 	public static String AUTHORIZED = "authorized";

--- a/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/util/IdGeneratorUtil.java
+++ b/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/util/IdGeneratorUtil.java
@@ -7,10 +7,10 @@ public class IdGeneratorUtil {
 
     public static  String generateIdWithTimestamp(String id) {
         Timestamp timestamp = new Timestamp(System.currentTimeMillis());
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd-HHmmss");
-        String currentMinute = sdf.format(timestamp);
+        SimpleDateFormat sdf = new SimpleDateFormat("yyyyMMdd-HHmmssSSS");
+        String currentTimestamp = sdf.format(timestamp);
 
-        return id + "_at_" + currentMinute;
+        return id + "_at_" + currentTimestamp;
     }
 
 }


### PR DESCRIPTION
- order listener checks is subscription end date is far enough in future that no renewal payment should be done
- subscription-renewal-order-created-event handling checks if there already is payment being processed
- subscription-renewal-order-created-event handling checks if another payment was made while processing this
- subscription-renewal-order-created-event saves MIT_CHARGE_PAID event to history
- Test method createSubsriptionOrderWithMerchantId creates mock product mapping for test product