### PR TITLE
KYV-1336 changes to fix refund payments check-and-fix cron job

### DIFF
--- a/common/src/main/java/fi/hel/verkkokauppa/common/payment/dto/UpdateFromPaytrailRefundDto.java
+++ b/common/src/main/java/fi/hel/verkkokauppa/common/payment/dto/UpdateFromPaytrailRefundDto.java
@@ -5,6 +5,7 @@ import lombok.Data;
 @Data
 public class UpdateFromPaytrailRefundDto {
 	private String refundId;
+	private String refundPaymentId;
 	private String merchantId;
 //	private String paytrailTransactionId;
 	private String namespace;

--- a/orderapi/src/main/java/fi/hel/verkkokauppa/order/api/cron/search/controllers/MissingRefundAccountingFinderController.java
+++ b/orderapi/src/main/java/fi/hel/verkkokauppa/order/api/cron/search/controllers/MissingRefundAccountingFinderController.java
@@ -10,6 +10,7 @@ import fi.hel.verkkokauppa.order.api.cron.search.SearchNotificationService;
 import fi.hel.verkkokauppa.order.api.cron.search.dto.RefundResultDto;
 import fi.hel.verkkokauppa.order.api.cron.search.refund.SearchUnAccountedRefunds;
 import fi.hel.verkkokauppa.order.service.refund.RefundItemService;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -53,7 +54,13 @@ public class MissingRefundAccountingFinderController {
 
     @GetMapping(value = "/accounting/cron/find-missing-refund-accounting", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<RefundResultDto>> findMissingAccountingsBasedOnRefundPaid(
+            @Parameter (description = "Datetime (yyyy-MM-dd'T'HH:mm:ss). " +
+                    "If left blank, all missing refund accountings are retrieved.")
             @RequestParam(value = "createdAfter", required = false) String createdAfter,
+
+            @Parameter (description = "Datetime (yyyy-MM-dd'T'HH:mm:ss). " +
+                    "If left blank, missing refund accountings are retrieved based on the given createdAfter parameter " +
+                    "but no refund accountings are created to correct the situation.")
             @RequestParam(value = "createAccountingAfter", required = false) String createAccountingAfter
     ) {
         try {
@@ -103,6 +110,7 @@ public class MissingRefundAccountingFinderController {
                 }
 
                 // Sends create accounting to experience api
+                // Note that this is sent only if createAccountingAfter value was given
                 this.experienceApiRefundAccountingService.sendCreateRefundAccountingRequests(failedToAccountAfterDate);
             }
 

--- a/orderapi/src/main/java/fi/hel/verkkokauppa/order/api/cron/search/refund/SearchUnAccountedRefunds.java
+++ b/orderapi/src/main/java/fi/hel/verkkokauppa/order/api/cron/search/refund/SearchUnAccountedRefunds.java
@@ -61,6 +61,7 @@ public class SearchUnAccountedRefunds {
 
                 UpdateFromPaytrailRefundDto dto = new UpdateFromPaytrailRefundDto();
                 dto.setRefundId(refund.getRefundId());
+                dto.setRefundPaymentId(refund.getRefundPaymentId());
                 dto.setMerchantId(merchantId);
                 dto.setNamespace(namespace);
 
@@ -102,7 +103,7 @@ public class SearchUnAccountedRefunds {
     }
 
     public List<RefundResultDto> findUnaccountedRefunds() throws IOException {
-        String refundStatus = "payment_paid_online";
+        String refundStatus = "refund_paid_online";
         return getRefundResultDtos(searchRefundService.findUnaccountedRefunds(), refundStatus);
     }
 

--- a/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/api/PaytrailRefundPaymentController.java
+++ b/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/api/PaytrailRefundPaymentController.java
@@ -58,13 +58,13 @@ public class PaytrailRefundPaymentController {
             @RequestParam(value = "merchantId") String merchantId,
             @RequestParam(value = "signature") String signature,
             @RequestParam(value = "checkout-status") String status,
-            @RequestParam(value = "checkout-stamp") String refundId,
+            @RequestParam(value = "checkout-stamp") String refundPaymentId,
             @RequestParam Map<String, String> checkoutParams
     ) {
         try {
-            boolean isValid = refundReturnValidator.validatePaytrailChecksum(checkoutParams, merchantId, signature, refundId);
+            boolean isValid = refundReturnValidator.validatePaytrailChecksum(checkoutParams, merchantId, signature, refundPaymentId);
             RefundReturnDto refundDto = refundReturnValidator.validatePaytrailRefundReturnValues(isValid, status);
-            refundPaymentService.updateRefundPaymentStatus(refundId, refundDto);
+            refundPaymentService.updateRefundPaymentStatus(refundPaymentId, refundDto);
             return ResponseEntity.status(HttpStatus.OK).body(refundDto);
         } catch (CommonApiException cae) {
             throw cae;
@@ -82,20 +82,41 @@ public class PaytrailRefundPaymentController {
             @RequestBody UpdateFromPaytrailRefundDto dto
     ) {
         try {
-            RefundPayment currentPayment = this.refundPaymentService.getRefundPaymentWithRefundId(dto.getRefundId());
-            PaytrailPayment paytrailRefund = paymentPaytrailService.getPaytrailPayment(currentPayment.getRefundTransactionId(), dto.getNamespace(), dto.getMerchantId());
-            RefundPayment updatedRefund = this.refundPaymentService.updateRefundWithPaytrailRefund(dto.getRefundId(), paytrailRefund);
-            if (
-                    currentPayment.getStatus().equalsIgnoreCase(RefundPaymentStatus.CREATED) &&
-                            updatedRefund.getPaymentProviderStatus().equalsIgnoreCase("OK")
-            ) {
-                // Update status to paid online because it was returned on paytrail side
-                updatedRefund = this.refundPaymentService.setRefundPaymentStatus(dto.getRefundId(), RefundPaymentStatus.PAID_ONLINE);
-                this.refundPaymentService.triggerRefundPaymentPaidEvent(
-                        updatedRefund
-                );
+            log.debug("updateRefundFromPaytrailRefund dto: {}", dto);
+            if (dto.getRefundPaymentId() != null && !dto.getRefundPaymentId().isEmpty()) {
+                log.debug("Found refundPaymentId.");
+                RefundPayment currentPayment = this.refundPaymentService.getRefundPaymentWithRefundPaymentId(dto.getRefundPaymentId());
+                PaytrailPayment paytrailRefund = paymentPaytrailService.getPaytrailPayment(currentPayment.getRefundTransactionId(), dto.getNamespace(), dto.getMerchantId());
+                RefundPayment updatedRefund = this.refundPaymentService.updateRefundWithPaytrailRefundUsingRefundPaymentId(dto.getRefundPaymentId(), paytrailRefund);
+                if (
+                        currentPayment.getStatus().equalsIgnoreCase(RefundPaymentStatus.CREATED) &&
+                                updatedRefund.getPaymentProviderStatus().equalsIgnoreCase("OK")
+                ) {
+                    // Update status to paid online because it was returned on paytrail side
+                    updatedRefund = this.refundPaymentService.setRefundPaymentStatus(dto.getRefundPaymentId(), RefundPaymentStatus.PAID_ONLINE);
+                    this.refundPaymentService.triggerRefundPaymentPaidEvent(
+                            updatedRefund
+                    );
+                }
+                return ResponseEntity.status(HttpStatus.OK).body(updatedRefund);
+            } else {
+                // Experience api must be able to use this method without refundPaymentId
+                log.debug("No refundPaymentId.");
+                RefundPayment currentPayment = this.refundPaymentService.getRefundPaymentWithRefundId(dto.getRefundId());
+                PaytrailPayment paytrailRefund = paymentPaytrailService.getPaytrailPayment(currentPayment.getRefundTransactionId(), dto.getNamespace(), dto.getMerchantId());
+                RefundPayment updatedRefund = this.refundPaymentService.updateRefundWithPaytrailRefundUsingRefundId(dto.getRefundId(), paytrailRefund);
+                if (
+                        currentPayment.getStatus().equalsIgnoreCase(RefundPaymentStatus.CREATED) &&
+                                updatedRefund.getPaymentProviderStatus().equalsIgnoreCase("OK")
+                ) {
+                    // Update status to paid online because it was returned on paytrail side
+                    updatedRefund = this.refundPaymentService.setRefundPaymentStatus(dto.getRefundId(), RefundPaymentStatus.PAID_ONLINE);
+                    this.refundPaymentService.triggerRefundPaymentPaidEvent(
+                            updatedRefund
+                    );
+                }
+                return ResponseEntity.status(HttpStatus.OK).body(updatedRefund);
             }
-            return ResponseEntity.status(HttpStatus.OK).body(updatedRefund);
         } catch (CommonApiException cae) {
             throw cae;
         } catch (Exception e) {

--- a/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/api/PaytrailRefundPaymentController.java
+++ b/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/api/PaytrailRefundPaymentController.java
@@ -84,7 +84,7 @@ public class PaytrailRefundPaymentController {
         try {
             log.debug("updateRefundFromPaytrailRefund dto: {}", dto);
             if (dto.getRefundPaymentId() != null && !dto.getRefundPaymentId().isEmpty()) {
-                log.debug("Found refundPaymentId.");
+                log.debug("Found refundPaymentId in updateRefundFromPaytrailRefund.");
                 RefundPayment currentPayment = this.refundPaymentService.getRefundPaymentWithRefundPaymentId(dto.getRefundPaymentId());
                 PaytrailPayment paytrailRefund = paymentPaytrailService.getPaytrailPayment(currentPayment.getRefundTransactionId(), dto.getNamespace(), dto.getMerchantId());
                 RefundPayment updatedRefund = this.refundPaymentService.updateRefundWithPaytrailRefundUsingRefundPaymentId(dto.getRefundPaymentId(), paytrailRefund);
@@ -101,16 +101,16 @@ public class PaytrailRefundPaymentController {
                 return ResponseEntity.status(HttpStatus.OK).body(updatedRefund);
             } else {
                 // Experience api must be able to use this method without refundPaymentId
-                log.debug("No refundPaymentId.");
+                log.debug("No refundPaymentId in updateRefundFromPaytrailRefund.");
                 RefundPayment currentPayment = this.refundPaymentService.getRefundPaymentWithRefundId(dto.getRefundId());
                 PaytrailPayment paytrailRefund = paymentPaytrailService.getPaytrailPayment(currentPayment.getRefundTransactionId(), dto.getNamespace(), dto.getMerchantId());
-                RefundPayment updatedRefund = this.refundPaymentService.updateRefundWithPaytrailRefundUsingRefundId(dto.getRefundId(), paytrailRefund);
+                RefundPayment updatedRefund = this.refundPaymentService.updateRefundWithPaytrailRefundUsingRefundPaymentId(currentPayment.getRefundPaymentId(), paytrailRefund);
                 if (
                         currentPayment.getStatus().equalsIgnoreCase(RefundPaymentStatus.CREATED) &&
                                 updatedRefund.getPaymentProviderStatus().equalsIgnoreCase("OK")
                 ) {
                     // Update status to paid online because it was returned on paytrail side
-                    updatedRefund = this.refundPaymentService.setRefundPaymentStatus(dto.getRefundId(), RefundPaymentStatus.PAID_ONLINE);
+                    updatedRefund = this.refundPaymentService.setRefundPaymentStatus(currentPayment.getRefundPaymentId(), RefundPaymentStatus.PAID_ONLINE);
                     this.refundPaymentService.triggerRefundPaymentPaidEvent(
                             updatedRefund
                     );

--- a/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/service/refund/PaytrailRefundPaymentService.java
+++ b/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/service/refund/PaytrailRefundPaymentService.java
@@ -77,8 +77,8 @@ public class PaytrailRefundPaymentService {
         }
     }
 
-    public RefundPayment setRefundPaymentStatus(String refundId, String status) {
-        RefundPayment refundPayment = getRefundPaymentWithRefundId(refundId);
+    public RefundPayment setRefundPaymentStatus(String refundPaymentId, String status) {
+        RefundPayment refundPayment = getRefundPaymentWithRefundPaymentId(refundPaymentId);
         refundPayment.setStatus(status);
         return refundPaymentRepository.save(refundPayment);
     }
@@ -144,11 +144,27 @@ public class PaytrailRefundPaymentService {
     }
 
     public RefundPayment getRefundPaymentWithRefundId(String refundId) {
-        return refundPaymentRepository.findById(refundId).orElseThrow(() -> {
-                    log.debug("refund payment not found, refundId: " + refundId);
+        try {
+            List <RefundPayment> payments = refundPaymentRepository.findByRefundId(refundId);
+            log.debug("getRefundPaymentWithRefundId found {} payments, picking up the first one by default", payments.size());
+            return payments.get(0);
+
+        } catch (Exception e) {
+            log.debug("refund payment not found, refundId: " + refundId);
+            throw new CommonApiException(
+                HttpStatus.NOT_FOUND,
+                new Error("refund-payment-not-found-from-backend", "refund payment with refund id [" + refundId + "] not found from backend")
+            );
+        }
+    }
+
+
+    public RefundPayment getRefundPaymentWithRefundPaymentId(String refundPaymentId) {
+        return refundPaymentRepository.findById(refundPaymentId).orElseThrow(() -> {
+                    log.debug("refund payment not found, refundPaymentId: " + refundPaymentId);
                     return new CommonApiException(
                             HttpStatus.NOT_FOUND,
-                            new Error("refund-payment-not-found-from-backend", "refund payment with refund id [" + refundId + "] not found from backend")
+                            new Error("refund-payment-not-found-from-backend", "refund payment with refund payment id [" + refundPaymentId + "] not found from backend")
                     );
                 }
         );
@@ -318,45 +334,65 @@ public class PaytrailRefundPaymentService {
         return refundPayment;
     }
 
-    public void updateRefundPaymentStatus(String refundId, RefundReturnDto refundReturnDto) {
-        RefundPayment refundPayment = getRefundPaymentWithRefundId(refundId);
+    public void updateRefundPaymentStatus(String refundPaymentId, RefundReturnDto refundReturnDto) {
+        log.debug("updateRefundPaymentStatus, refundPaymentId: " + refundPaymentId);
+        RefundPayment refundPayment = getRefundPaymentWithRefundPaymentId(refundPaymentId);
 
         if (refundReturnDto.isValid()) {
             if (refundReturnDto.isRefundPaid()) {
                 // if not already paid earlier
                 if (!RefundPaymentStatus.PAID_ONLINE.equals(refundPayment.getStatus())) {
-                    setRefundPaymentStatus(refundId, RefundPaymentStatus.PAID_ONLINE);
+                    setRefundPaymentStatus(refundPaymentId, RefundPaymentStatus.PAID_ONLINE);
                     triggerRefundPaymentPaidEvent(refundPayment);
                 } else {
-                    log.debug("not triggering events, refundPayment paid earlier, refundId: " + refundId);
+                    log.debug("not triggering events, refundPayment paid earlier, refundPaymentId: " + refundPaymentId);
                 }
             } else if (!refundReturnDto.isRefundPaid() && !refundReturnDto.isCanRetry()) {
                 // if not already cancelled earlier
                 if (!RefundPaymentStatus.CANCELLED.equals(refundPayment.getStatus())) {
-                    setRefundPaymentStatus(refundId, RefundPaymentStatus.CANCELLED);
+                    setRefundPaymentStatus(refundPaymentId, RefundPaymentStatus.CANCELLED);
                     triggerRefundPaymentFailedEvent(refundPayment);
                 } else {
-                    log.debug("not triggering events, refund refundPayment cancelled earlier, refundId: " + refundId);
+                    log.debug("not triggering events, refund refundPayment cancelled earlier, refundPaymentId: " + refundPaymentId);
                 }
             } else {
-                log.debug("not triggering events, refund refundPayment not paid but can be retried, refundId: " + refundId);
+                log.debug("not triggering events, refund refundPayment not paid but can be retried, refundPaymentId: " + refundPaymentId);
             }
         }
     }
 
-    public RefundPayment updateRefundWithPaytrailRefund(String refundId, PaytrailPayment paytrailPayment) {
+    public RefundPayment updateRefundWithPaytrailRefundUsingRefundId(String refundId, PaytrailPayment paytrailPayment) {
 
+        log.debug("updateRefundWithPaytrailRefundUsingRefundId, refundId: " + refundId);
         RefundPayment refundPayment = this.getRefundPaymentWithRefundId(refundId);
         if (paytrailPayment.paidAt != null) {
             LocalDateTime paidAt = DateTimeUtil.offsetDateTimeToLocalDateTime(paytrailPayment.paidAt);
             refundPayment.setPaidAt(paidAt);
         } else {
-            log.debug("updateRefundWithPaytrailRefund paymentId: {}. paytrailPayment.paidAt was null.", refundId);
+            log.debug("updateRefundWithPaytrailRefundUsingRefundId refundId: {}. paytrailPayment.paidAt was null.", refundId);
         }
         if (paytrailPayment.status != null) {
             refundPayment.setPaymentProviderStatus(paytrailPayment.status);
         } else {
-            log.debug("updateRefundWithPaytrailRefund paymentId: {}. paytrailPayment.status was null.", refundId);
+            log.debug("updateRefundWithPaytrailRefundUsingRefundId refundId: {}. paytrailPayment.status was null.", refundId);
+        }
+        return refundPaymentRepository.save(refundPayment);
+    }
+
+    public RefundPayment updateRefundWithPaytrailRefundUsingRefundPaymentId(String refundPaymentId, PaytrailPayment paytrailPayment) {
+
+        log.debug("updateRefundWithPaytrailRefund, refundPaymentId: " + refundPaymentId);
+        RefundPayment refundPayment = this.getRefundPaymentWithRefundPaymentId(refundPaymentId);
+        if (paytrailPayment.paidAt != null) {
+            LocalDateTime paidAt = DateTimeUtil.offsetDateTimeToLocalDateTime(paytrailPayment.paidAt);
+            refundPayment.setPaidAt(paidAt);
+        } else {
+            log.debug("updateRefundWithPaytrailRefundUsingRefundPaymentId refundPaymentId: {}. paytrailPayment.paidAt was null.", refundPaymentId);
+        }
+        if (paytrailPayment.status != null) {
+            refundPayment.setPaymentProviderStatus(paytrailPayment.status);
+        } else {
+            log.debug("updateRefundWithPaytrailRefundUsingRefundPaymentId refundPaymentId: {}. paytrailPayment.status was null.", refundPaymentId);
         }
         return refundPaymentRepository.save(refundPayment);
     }

--- a/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/service/refund/PaytrailRefundPaymentService.java
+++ b/paymentapi/src/main/java/fi/hel/verkkokauppa/payment/service/refund/PaytrailRefundPaymentService.java
@@ -361,24 +361,6 @@ public class PaytrailRefundPaymentService {
         }
     }
 
-    public RefundPayment updateRefundWithPaytrailRefundUsingRefundId(String refundId, PaytrailPayment paytrailPayment) {
-
-        log.debug("updateRefundWithPaytrailRefundUsingRefundId, refundId: " + refundId);
-        RefundPayment refundPayment = this.getRefundPaymentWithRefundId(refundId);
-        if (paytrailPayment.paidAt != null) {
-            LocalDateTime paidAt = DateTimeUtil.offsetDateTimeToLocalDateTime(paytrailPayment.paidAt);
-            refundPayment.setPaidAt(paidAt);
-        } else {
-            log.debug("updateRefundWithPaytrailRefundUsingRefundId refundId: {}. paytrailPayment.paidAt was null.", refundId);
-        }
-        if (paytrailPayment.status != null) {
-            refundPayment.setPaymentProviderStatus(paytrailPayment.status);
-        } else {
-            log.debug("updateRefundWithPaytrailRefundUsingRefundId refundId: {}. paytrailPayment.status was null.", refundId);
-        }
-        return refundPaymentRepository.save(refundPayment);
-    }
-
     public RefundPayment updateRefundWithPaytrailRefundUsingRefundPaymentId(String refundPaymentId, PaytrailPayment paytrailPayment) {
 
         log.debug("updateRefundWithPaytrailRefund, refundPaymentId: " + refundPaymentId);


### PR DESCRIPTION
The search used by refund payments check can now be called with both refundId and refundPaymentId. Earlier, when only refundId was allowed, the search did not work correctly. 

There are also some typo/copy-paste error bug fixes and some small description refinements for swagger UI.